### PR TITLE
PHB-10: Add Sonarcloud code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ node_js:
 
 cache:
   directories:
+    - "$HOME/.sonar/cache"
     - "node_modules"
     - "build"
 
 stages:
   - setup
   - build
+  - sonar
   - deploy
 
 jobs:
@@ -21,6 +23,13 @@ jobs:
     - stage: build
       script:
         - npm run build
+    - stage: sonar
+      script:
+        - sonar-scanner
+      addons:
+        sonarcloud:
+          token:
+            secure: "$SONAR_API_KEY"
     - stage: deploy
       deploy:
         provider: heroku

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an MIT license for anyone to use the application
 - Added `/collections` directory which includes postman and insomnia workspaces for accessing the API
 - Added `Loggly` to the bunyan logger for external logging on production
+- Added `sonar` cloud analysis in the CI
 
 ### Updated
 - Fleshed out the README a bit more. Documented the endpoints, environment etc...

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+##################
+# Project Settings
+######################
+sonar.projectKey=phonebook-rest-api
+sonar.organization=skaleb
+sonar.projectName=Phonebook RESTful API
+sonar.projectVersion=1.0
+
+##################
+# Project Directories
+######################
+#sonar.tests=test
+sonar.sources=src
+#sonar.typescript.lcov.reportPaths=coverage/lcov.info
+#sonar.exclusions=src/index.ts, src/types/**/*.ts, src/models/**/*.ts, src/errors/**/*.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 ##################
 # Project Settings
 ######################
-sonar.projectKey=phonebook-rest-api
+sonar.projectKey=ToeFungi_phonebook-api
 sonar.organization=skaleb
 sonar.projectName=Phonebook RESTful API
 sonar.projectVersion=1.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,15 +1,15 @@
 ##################
 # Project Settings
 ######################
-sonar.projectKey=ToeFungi_phonebook-api
-sonar.organization=skaleb
+sonar.projectKey=phonebook-rest-api
 sonar.projectName=Phonebook RESTful API
 sonar.projectVersion=1.0
+sonar.organization=skaleb
 
 ##################
 # Project Directories
 ######################
-#sonar.tests=test
+sonar.tests=test
 sonar.sources=src
-#sonar.typescript.lcov.reportPaths=coverage/lcov.info
-#sonar.exclusions=src/index.ts, src/types/**/*.ts, src/models/**/*.ts, src/errors/**/*.ts
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.exclusions=src/index.ts, src/types/**/*.ts, src/models/**/*.ts


### PR DESCRIPTION
No analysis on the code is being run during the CI process. This needs to change so that any possible security vulnerabilities, code smells and bugs might be detected before they become an issue in production. Sonarcloud has been chosen because it is free for public repositories and already analyses various other projects.

**Acceptance Criteria**
**Given** a developer,
**When** new code is committed,
**Then** sonarcloud analyses the new code

[Ticket PHB-10](https://trello.com/c/a7aP6tJb)