### PR TITLE
PHB-11: Add correlation ID to logger data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - npm run build
     - stage: sonar
       script:
-        - sonar-scanner -X
+        - sonar-scanner
       addons:
         sonarcloud:
           organization: "skaleb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -32,11 +31,18 @@
         "@types/node": "*"
       }
     },
+    "@types/cls-hooked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.0.tgz",
+      "integrity": "sha512-H2ov/zMqgs7b66dkfufx3SXMnYFn6u9IOMEY7JZYWXJhE/WVZogedXsQIgM/504DyvtbNNXMiofaRr1E0+3yZA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -45,7 +51,6 @@
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
       "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -56,7 +61,6 @@
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
       "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -65,8 +69,7 @@
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
-      "dev": true
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/mongodb": {
       "version": "3.3.16",
@@ -81,24 +84,27 @@
     "@types/node": {
       "version": "13.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
-      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
-      "dev": true
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
       "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-      "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.7.tgz",
+      "integrity": "sha512-C2j2FWgQkF1ru12SjZJyMaTPxs/f6n90+5G5qNakBxKXjTBc/YTSelHh4Pz1HUDwxFXD9WvpQhOGCDC+/Y4mIQ==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -183,6 +189,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -368,6 +382,16 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -556,6 +580,14 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -627,6 +659,16 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-http-context": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/express-http-context/-/express-http-context-1.2.3.tgz",
+      "integrity": "sha512-Cde8XZJ8qYc4ACZSwn2NxuBG6mnPfXDtJUW+Ppgb2AhyNP4ttESK2SrYfAk6CluFADbxy24C5mVP25sOeBAgbQ==",
+      "requires": {
+        "@types/cls-hooked": "^4.2.1",
+        "@types/express": "^4.16.0",
+        "cls-hooked": "^4.2.2"
       }
     },
     "extend": {
@@ -1600,6 +1642,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -1646,6 +1693,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "statuses": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,16 @@
   "author": "Alex Pickering",
   "license": "ISC",
   "dependencies": {
+    "uuid": "3.4.0",
     "dotenv": "8.2.0",
     "bunyan": "1.8.12",
     "mongodb": "3.5.3",
     "express": "4.17.1",
-    "bunyan-loggly": "1.4.1"
+    "bunyan-loggly": "1.4.1",
+    "express-http-context": "1.2.3"
   },
   "devDependencies": {
+    "@types/uuid": "3.4.7",
     "@types/bunyan": "1.8.6",
     "@types/express": "4.17.2",
     "@types/mongodb": "3.3.16",

--- a/src/factories/app-factory.ts
+++ b/src/factories/app-factory.ts
@@ -1,7 +1,9 @@
 import * as express from 'express'
+import * as HTTPContext from 'express-http-context'
 
 import { HealthController } from '../controllers/health-controller'
 import { ContactsController } from '../controllers/contacts-controller'
+import { CorrelationIdMiddleware } from '../middleware/correlation-id-middleware'
 
 /**
  * App Factory creates and initializes and new instance of the application
@@ -13,6 +15,9 @@ class AppFactory {
   public static getInstance(contactsController: ContactsController,
                             healthController: HealthController): express.Express {
     const app: express.Express = express()
+
+    app.use(HTTPContext.middleware)
+    app.use(CorrelationIdMiddleware.getMiddleware())
 
     app.use('/health', healthController.getRoutes())
     app.use('/contacts', contactsController.getRoutes())

--- a/src/factories/logger-factory.ts
+++ b/src/factories/logger-factory.ts
@@ -1,5 +1,6 @@
 import * as Logger from 'bunyan'
 import * as BunyanLoggly from 'bunyan-loggly'
+import * as HTTPContext from 'express-http-context'
 
 import { LoggerConfiguration } from '../models/configuration/logger-configuration'
 import { StreamCorrelationIdDecorator } from '../lib/stream-correlation-id-decorator'
@@ -39,7 +40,7 @@ class LoggerFactory {
   }
 
   /**
-   * Gets a stream used for logging raw output
+   * Get a configured raw stream for bunyan to use
    */
   private getRawStream(configuration: LoggerConfiguration): NodeJS.WritableStream {
     const loggly = new BunyanLoggly({
@@ -47,9 +48,7 @@ class LoggerFactory {
       subdomain: configuration.logglySubdomain
     }) as NodeJS.WritableStream
 
-    return new StreamCorrelationIdDecorator(loggly, () => {
-      return 'some-correlation-id'
-    })
+    return new StreamCorrelationIdDecorator(loggly, HTTPContext.get)
   }
 }
 

--- a/src/lib/stream-correlation-id-decorator.ts
+++ b/src/lib/stream-correlation-id-decorator.ts
@@ -16,6 +16,9 @@ function isObject(obj: any): boolean {
 class StreamCorrelationIdDecorator extends EventEmitter implements NodeJS.WritableStream {
   writable: boolean = true
 
+  /**
+   * @constructor
+   */
   constructor(private stream: NodeJS.WritableStream, private getContextVariable: (param: string) => string) {
     super()
   }

--- a/src/lib/stream-correlation-id-decorator.ts
+++ b/src/lib/stream-correlation-id-decorator.ts
@@ -28,17 +28,12 @@ class StreamCorrelationIdDecorator extends EventEmitter implements NodeJS.Writab
    */
   public write(record: any): boolean {
     try {
-      const logObject: any = isObject(record) ? record : JSON.parse(record)
-      const correlationId: string = this.getContextVariable('correlationId')
-      console.log('correlationId', { correlationId })
+      const loggerData: any = isObject(record) ? record : JSON.parse(record)
 
-      if (correlationId) {
-        logObject.correlationId = correlationId
-      }
+      loggerData.correlationId = this.getContextVariable('correlationId') ?? ''
 
-      return this.stream.write(JSON.stringify(logObject) + '\n')
+      return this.stream.write(JSON.stringify(loggerData) + '\n')
     } catch (_) {
-      console.log('failing')
       return this.stream.write(record)
     }
   }

--- a/src/lib/stream-correlation-id-decorator.ts
+++ b/src/lib/stream-correlation-id-decorator.ts
@@ -16,17 +16,18 @@ function isObject(obj: any): boolean {
 class StreamCorrelationIdDecorator extends EventEmitter implements NodeJS.WritableStream {
   writable: boolean = true
 
-  constructor(private stream: NodeJS.WritableStream, private getContextVariable: (param: string) => any) {
+  constructor(private stream: NodeJS.WritableStream, private getContextVariable: (param: string) => string) {
     super()
   }
 
   /**
    * Write the record to the supplied writable stream with the additional `correlationId` if available.
    */
-  write(record: any): boolean {
+  public write(record: any): boolean {
     try {
       const logObject: any = isObject(record) ? record : JSON.parse(record)
       const correlationId: string = this.getContextVariable('correlationId')
+      console.log('correlationId', { correlationId })
 
       if (correlationId) {
         logObject.correlationId = correlationId
@@ -34,6 +35,7 @@ class StreamCorrelationIdDecorator extends EventEmitter implements NodeJS.Writab
 
       return this.stream.write(JSON.stringify(logObject) + '\n')
     } catch (_) {
+      console.log('failing')
       return this.stream.write(record)
     }
   }
@@ -41,7 +43,7 @@ class StreamCorrelationIdDecorator extends EventEmitter implements NodeJS.Writab
   /**
    * @inheritdoc
    */
-  end(record?: any): void {
+  public end(record?: any): void {
     return this.stream.end(record)
   }
 }

--- a/src/lib/stream-correlation-id-decorator.ts
+++ b/src/lib/stream-correlation-id-decorator.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from 'events'
+
+/**
+ * Predicate to test if parameter is an object
+ *
+ * @param obj parameter to test
+ * @returns true if parameter is an object
+ */
+function isObject(obj: any): boolean {
+  return typeof (obj) === 'object'
+}
+
+/**
+ * Decorator for a writeable stream to include correlationId with each record.
+ */
+class StreamCorrelationIdDecorator extends EventEmitter implements NodeJS.WritableStream {
+  writable: boolean = true
+
+  constructor(private stream: NodeJS.WritableStream, private getContextVariable: (param: string) => any) {
+    super()
+  }
+
+  /**
+   * Write the record to the supplied writable stream with the additional `correlationId` if available.
+   */
+  write(record: any): boolean {
+    try {
+      const logObject: any = isObject(record) ? record : JSON.parse(record)
+      const correlationId: string = this.getContextVariable('correlationId')
+
+      if (correlationId) {
+        logObject.correlationId = correlationId
+      }
+
+      return this.stream.write(JSON.stringify(logObject) + '\n')
+    } catch (_) {
+      return this.stream.write(record)
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  end(record?: any): void {
+    return this.stream.end(record)
+  }
+}
+
+export { StreamCorrelationIdDecorator }

--- a/src/middleware/correlation-id-middleware.ts
+++ b/src/middleware/correlation-id-middleware.ts
@@ -1,0 +1,21 @@
+import * as uuid from 'uuid'
+import * as HTTPContext from 'express-http-context'
+
+import { NextFunction, Request, Response } from 'express'
+
+class CorrelationIdMiddleware {
+  public static getMiddleware() {
+    return (req: Request, res: Response, next: NextFunction) => {
+      const correlationId: string = req.get('correlationId') ?? uuid.v4()
+
+      req.headers['correlationId'] = correlationId
+      res.set('correlationId', correlationId)
+
+      HTTPContext.set('correlationId', correlationId)
+
+      next()
+    }
+  }
+}
+
+export { CorrelationIdMiddleware }

--- a/src/middleware/correlation-id-middleware.ts
+++ b/src/middleware/correlation-id-middleware.ts
@@ -3,7 +3,14 @@ import * as HTTPContext from 'express-http-context'
 
 import { NextFunction, Request, Response } from 'express'
 
+/**
+ * Correlation ID middleware component extracts an existing correlation ID, if it exists, from the incoming request, or
+ * generates a new correlation ID and attaches it to the request, the response and sets it to the request context
+ */
 class CorrelationIdMiddleware {
+  /**
+   * Get the middleware component
+   */
   public static getMiddleware() {
     return (req: Request, res: Response, next: NextFunction) => {
       const correlationId: string = req.get('correlationId') ?? uuid.v4()


### PR DESCRIPTION
Although the logs are now being centralised using Loggly, there is no way to distinguish a full request in the logs. There needs to be an ID set per request so that log data may be correlated.

**Acceptance Criteria**
**Given** a developer
**When** sifting through the logs,
**Then** a full request can be tracked with an ID

[Trello Ticket PHB-11](https://trello.com/c/Y7muvYs9)